### PR TITLE
Add type declarations for typescript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,96 @@
+import React from 'react';
+import type { CollapseProps } from 'antd/lib/collapse';
+
+export interface EditorListChangeState {
+  /**
+   * parent selectors
+   */
+  parentClassName: string;
+
+  /**
+   * edit css value
+   */
+  cssValue: any;
+
+  /**
+   * edit className
+   */
+  cssName: string;
+
+  /**
+   * Selectors replace(/[^a-z]/ig, ''), render style id
+   */
+  id: string;
+
+  /**
+   * edit random id
+   */
+  editClassName: string;
+
+  /**
+   * all css string, including events and terminals
+   */
+  allCssString: string;
+
+  /**
+   * current css string
+   */
+  currentEditCssString: string;
+
+  /**
+   * Is the color or slider changed by dragging
+   */
+  isDrag: boolean;
+}
+
+export interface EditorListProps extends Omit<CollapseProps, 'onChange'> {
+  /**
+   * editor dom
+   */
+  editorElem: HTMLElement;
+
+  /**
+   * change callback(e: changeCallBack)
+   */
+  onChange?: (state: EditorListChangeState) => void;
+
+  /**
+   * use className or style
+   */
+  useClassName?: boolean;
+
+  /**
+   * edit mobile style
+   */
+  isMobile?: boolean;
+
+  /**
+   * default editor class name, Cannot with current className
+   */
+  editorDefaultClassName?: string;
+
+  /**
+   * parent can use tag name
+   */
+  parentClassNameCanUseTagName?: boolean;
+
+  /**
+   * parent class name length
+   */
+  parentClassNameLength?: number;
+
+  /**
+   * root class name
+   */
+  rootSelector?: string;
+
+  /**
+   * insert css into dom
+   */
+  cssToDom?: boolean;
+}
+
+/**
+ * React EditorList Component
+ */
+export default class EditorList extends React.Component<EditorListProps> {}

--- a/package.json
+++ b/package.json
@@ -22,11 +22,13 @@
     "lib",
     "assets/*.css",
     "dist",
-    "es"
+    "es",
+    "index.d.ts"
   ],
   "licenses": "MIT",
   "main": "./lib/index",
   "module": "./es/index",
+  "types": "./index.d.ts",
   "config": {
     "port": 8022,
     "entry": {
@@ -50,6 +52,7 @@
     "coverage": "rc-tools run coverage"
   },
   "devDependencies": {
+    "@types/react": "16.x",
     "expect.js": "0.3.x",
     "pre-commit": "1.x",
     "precommit-hook": "1.x",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "strict": true
+  },
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
This adds a type declaration file for typescript, along with the package.json key needed to cause TypeScript to pick up those type declarations.